### PR TITLE
Remove redundant mkdir in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM node
 
 ENV BACK_PORT 80
 
-RUN mkdir /app
 WORKDIR /app
 
 COPY package.json package-lock.json ./


### PR DESCRIPTION
> **If the WORKDIR doesn’t exist, it will be created** even if it’s not used in any subsequent Dockerfile instruction.

https://docs.docker.com/engine/reference/builder/#workdir